### PR TITLE
MAKE-982: register handlers without context as fallback

### DIFF
--- a/mongowire/scope.go
+++ b/mongowire/scope.go
@@ -17,10 +17,6 @@ func (s *OpScope) Validate() error {
 			return errors.New("commands much identify a named command")
 		}
 
-		if s.Context == "" {
-			return errors.New("command ops must specify a scope (dbname only)")
-		}
-
 		return nil
 	case OP_DELETE:
 		if s.Context == "" {

--- a/registry.go
+++ b/registry.go
@@ -37,6 +37,14 @@ func (o *OperationRegistry) Get(scope *mongowire.OpScope) (HandlerFunc, bool) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 
-	handler, ok := o.ops[*scope]
+	scopeCopy := *scope
+	if handler, ok := o.ops[scopeCopy]; ok {
+		return handler, ok
+	}
+
+	// Default to using a handler without a context if there isn't a more
+	// specific context match.
+	scopeCopy.Context = ""
+	handler, ok := o.ops[scopeCopy]
 	return handler, ok
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-982

If the context (i.e. collection/db name) is not an exact match, let it use a fallback handler without a context if it exists.