### PR TITLE
MAKE-983: close connection and check for EOF

### DIFF
--- a/service.go
+++ b/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evergreen-ci/birch"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 	"github.com/tychoish/mongorpc/mongowire"
@@ -50,7 +51,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 		conn, err := l.Accept()
 		if err != nil {
-			grip.Warning(errors.Wrap(err, "problem accepting connection"))
+			grip.Warning(message.WrapError(err, "problem accepting connection"))
 			continue
 		}
 
@@ -75,14 +76,14 @@ func (s *Service) dispatchRequest(ctx context.Context, conn net.Conn) {
 	defer func() {
 		err := recovery.HandlePanicWithError(recover(), nil, "request handling")
 		if err != nil {
-			grip.Error(errors.Wrap(err, "error during request handling"))
+			grip.Error(message.WrapError(err, "error during request handling"))
 			if writeErr := writeErrorReply(conn, err); writeErr != nil {
-				grip.Error(errors.Wrap(writeErr, "error writing reply after panic recovery"))
+				grip.Error(message.WrapError(writeErr, "error writing reply after panic recovery"))
 				return
 			}
 		}
 		if err := conn.Close(); err != nil {
-			grip.Error(errors.Wrapf(err, "error closing connection from %s", conn.RemoteAddr()))
+			grip.Error(message.WrapErrorf(err, "error closing connection from %s", conn.RemoteAddr()))
 			return
 		}
 		grip.Infof("closed connection from %s", conn.RemoteAddr())
@@ -91,7 +92,7 @@ func (s *Service) dispatchRequest(ctx context.Context, conn net.Conn) {
 	if c, ok := conn.(*tls.Conn); ok {
 		// we do this here so that we can get the SNI server name
 		if err := c.Handshake(); err != nil {
-			grip.Warning(errors.Wrap(err, "error doing tls handshake"))
+			grip.Warning(message.WrapError(err, "error doing tls handshake"))
 			return
 		}
 		grip.Debugf("ssl connection to %s", c.ConnectionState().ServerName)
@@ -103,7 +104,7 @@ func (s *Service) dispatchRequest(ctx context.Context, conn net.Conn) {
 			if errors.Cause(err) == io.EOF {
 				return
 			}
-			grip.Error(errors.Wrap(err, "problem reading message"))
+			grip.Error(message.WrapError(err, "problem reading message"))
 			return
 		}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-983

* Do not continue on error after `ReadMessage()` because the connection handler panics if it fails to read a message (due to EOF or otherwise).
* Close the connection only once we attempt to write a reply due to panic.